### PR TITLE
Fix error on buildings without square footage info

### DIFF
--- a/src/app/templates/scorecards/building.html
+++ b/src/app/templates/scorecards/building.html
@@ -313,8 +313,8 @@
             </table>
           </div>
           <div class="text-asterisk">
-            *Compliance Year Deadlines for Buildings <%= sfRangeText %> SF are
-            October 1st of the year specified.
+            *Compliance Year Deadlines <%= sfRangeText %> are October 1st of the
+            year specified.
           </div>
           <div class="text-asterisk">
             ** Targets are estimated by prorating the published BEPS targets for

--- a/src/app/views/scorecards/building_scorecard.js
+++ b/src/app/views/scorecards/building_scorecard.js
@@ -362,14 +362,16 @@ define([
           range => range[0] <= totalGfa && (!range[1] || range[1] >= totalGfa)
         );
 
+        if (!relevantAmounts) return '';
+
         relevantAmounts = relevantAmounts.map(numberWithCommas);
 
         let rangeText = ``;
 
         if (relevantAmounts.length === 1) {
-          rangeText = `> ${relevantAmounts[0]} SF`;
+          rangeText = `for Buildings > ${relevantAmounts[0]} SF`;
         } else {
-          rangeText = `${relevantAmounts[0]}-${relevantAmounts[1]}`;
+          rangeText = `for Buildings ${relevantAmounts[0]}-${relevantAmounts[1]} SF`;
         }
         return rangeText;
       };

--- a/src/app/views/scorecards/building_scorecard.js
+++ b/src/app/views/scorecards/building_scorecard.js
@@ -351,6 +351,7 @@ define([
           (building?.thirdlargestpropertyusetypegfa ?? 0);
 
         const amounts = [
+          [0, 20000],
           [20001, 30000],
           [30001, 50000],
           [50001, 90000],
@@ -364,14 +365,16 @@ define([
 
         if (!relevantAmounts) return '';
 
-        relevantAmounts = relevantAmounts.map(numberWithCommas);
+        const relevantAmountsText = relevantAmounts.map(numberWithCommas);
 
         let rangeText = ``;
 
-        if (relevantAmounts.length === 1) {
-          rangeText = `for Buildings > ${relevantAmounts[0]} SF`;
+        if (relevantAmounts === amounts[0]) {
+          rangeText = `for Buildings < ${relevantAmountsText[1]} SF`;
+        } else if (relevantAmounts === amounts[amounts.length - 1]) {
+          rangeText = `for Buildings > ${relevantAmountsText[0]} SF`;
         } else {
-          rangeText = `for Buildings ${relevantAmounts[0]}-${relevantAmounts[1]} SF`;
+          rangeText = `for Buildings ${relevantAmountsText[0]}-${relevantAmountsText[1]} SF`;
         }
         return rangeText;
       };


### PR DESCRIPTION
Fixes https://github.com/GreenInfo-Network/seattle-building-dashboard/issues/133

Good catch here! This PR should handle two situations:
- building does not have square footage data
- building square footage is below 20,000

Since this code isn't directly in the charts I didn't think to make a failsafe previously.