### PR TITLE
Building scorecard: Minor bolding update

### DIFF
--- a/src/app/templates/scorecards/charts/first_compliance_interval.html
+++ b/src/app/templates/scorecards/charts/first_compliance_interval.html
@@ -3,9 +3,9 @@
     <% if (cbps_flag) { %>
     <span>This Tier 1 building</span>
     <% if (_isMeetingTarget) { %>
-    <span class="text-copy-semibold">is</span>
+    <span>is</span>
     <% } else { %>
-    <span class="text-copy-semibold">is not</span>
+    <span>is </span><span class="text-copy-semibold">not</span>
     <% } %>
     <span class="text-copy-semibold">on track</span
     ><span>

--- a/src/app/templates/scorecards/charts/first_ghgi_target.html
+++ b/src/app/templates/scorecards/charts/first_ghgi_target.html
@@ -2,9 +2,9 @@
   <div class="first-ghgi-target-text-container text-copy">
     <span>This building</span>
     <% if (_isMeetingTarget) { %>
-    <span class="text-copy-semibold">is</span>
+    <span>is</span>
     <% } else { %>
-    <span class="text-copy-semibold">is not</span>
+    <span>is </span><span class="text-copy-semibold">not</span>
     <% } %>
     <span class="text-copy-semibold">on track</span
     ><span>


### PR DESCRIPTION
Followup to https://github.com/GreenInfo-Network/seattle-building-dashboard/pull/138

Minor correction to only bold "on track" or "not on track" vs "is on track" etc for the first ghgi target and compliance interval.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201108652060192/1208961576755888)
