### PR TITLE
Additional feedback

### DIFF
--- a/src/app/views/scorecards/charts/beps.js
+++ b/src/app/views/scorecards/charts/beps.js
@@ -236,7 +236,7 @@ define([
 
         const yPos = Number(height) - Number(height) * multiplier;
 
-        const targetText = `${year}: target ${target.toFixed(2)}`;
+        const targetText = `${year} target: ${target.toFixed(2)}`;
 
         svg
           .append('line')

--- a/src/app/views/scorecards/charts/performance_over_time.js
+++ b/src/app/views/scorecards/charts/performance_over_time.js
@@ -37,13 +37,17 @@ define([
         return false;
       }
 
-      const validated = data.map(d =>
-        validateBuildingData(d, {
-          id: 'string',
-          value: 'number',
-          year: 'number'
-        })
-      );
+      const validated = data
+        // Some points haven't been reported, but this shouldn't invalidate it
+        // Remove unreported points
+        .filter(d => d.value !== null && d.value !== undefined)
+        .map(d =>
+          validateBuildingData(d, {
+            id: 'string',
+            value: 'number',
+            year: 'number'
+          })
+        );
 
       const valid = validated.every(d => d.valid);
       const typedData = validated.map(d => d.typedData);

--- a/src/styles/main/_scorecard.scss
+++ b/src/styles/main/_scorecard.scss
@@ -542,16 +542,9 @@ $dataviz-negative: #94778b;
   bottom: 0;
   width: 100%;
   background: $white;
-  overflow: auto;
   z-index: $zIndexMax;
   height: 100%;
-
-  // Hide scrollbar
-  &::-webkit-scrollbar {
-    display: none;
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
+  overflow-y: scroll;
 
   &.active {
     display: block;

--- a/src/styles/main/_scorecard.scss
+++ b/src/styles/main/_scorecard.scss
@@ -544,6 +544,14 @@ $dataviz-negative: #94778b;
   background: $white;
   overflow: auto;
   z-index: $zIndexMax;
+  height: 100%;
+
+  // Hide scrollbar
+  &::-webkit-scrollbar {
+    display: none;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
 
   &.active {
     display: block;


### PR DESCRIPTION
* Updates some language (eg `2031: target 0.31` => `2031 target: 0.31`
* Should always show scroll bars to avoid page misalignment
* Allows null values in performance over time chart and just doesn't show them as data points



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201108652060192/1208962110418744)
