### PR TITLE
Fix tab initial setting building report

### DIFF
--- a/src/app/views/scorecards/controller.js
+++ b/src/app/views/scorecards/controller.js
@@ -88,7 +88,8 @@ define([
       this.viewclass = BuildingScorecard;
       // Set initial tab on load
       if (this.state.get('report_active') === true) {
-        this.state.set({ tab: 'benchmarking_overview' });
+        const initialTab = this.state.get('tab') ?? 'benchmarking_overview';
+        this.state.set({ tab: initialTab });
       }
       this.render();
     },


### PR DESCRIPTION
Tabs weren't being set on initial load from the URL. This PR fixes that so you can share the building report to a specific tab